### PR TITLE
Add cancelled ajax requests sample

### DIFF
--- a/7_operators/operators.js
+++ b/7_operators/operators.js
@@ -12,6 +12,7 @@ const pipeArray = [
 ];
 
 // Pipe effect
+/*
 Rx.Observable
   .zip(Rx.Observable.interval(500), 
        Rx.Observable.from(pipeArray))
@@ -22,3 +23,22 @@ Rx.Observable
   .subscribe((word) => {
     console.log(word);
 });
+*/
+
+// Cancelled ajax requests sample
+Rx.Observable.zip(
+  Rx.Observable.interval(1000),
+  Rx.Observable.from(
+    [
+      'http://localhost:3000/users/1',
+      'http://localhost:3000/users/2',
+      'http://localhost:3000/users/3'
+    ])
+)
+  .do(valueAndUri => console.log(valueAndUri))
+  .switchMap(valueAndUri => Rx.Observable.ajax(valueAndUri[1]))
+  .subscribe(
+  (res) => console.log(res.response),
+  (err) => console.log(`Something went wrong ${err}`),
+  () => console.log('All ajax requests have finished')
+  );


### PR DESCRIPTION
Hi Lehel,

During the Wednesday workshop you had a comment about the power of RX vs Promises. The gist of it was that you can cancel Rx calls, but not Promises.

I've spent a bit of time on getting a sample working, and this is what I came up with. I've put it in the operators chapter since it is based on the switchMap operator.

Thanks for mentioning this behavior, it gives a me a good reason to use more of Rx in our project.